### PR TITLE
feat: add auto publish when an auto release tag is created

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,5 +30,4 @@ jobs:
           npm set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
           npm publish --access public
         env:
-          CI: true
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,34 @@
+name: Publish to npm Registry
+
+on:
+  push:
+    tags: 
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v3
+        
+      - name: install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: increment version
+        run: |
+          npm set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
+          npm --no-git-tag-version version from-git
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: publish
+        run: |
+          npm set //registry.npmjs.org/:_authToken $NODE_AUTH_TOKEN
+          npm publish --access public
+        env:
+          CI: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
I created a classic token with the publish access as our NODE_AUTH_TOKEN.
Reference reading:
https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages

<img width="830" alt="Screen Shot 2023-04-17 at 5 49 17 PM" src="https://user-images.githubusercontent.com/23131735/232640795-6c87a279-0972-494b-8bd2-39ebecc41b19.png">
