### PR TITLE
fix: Fix npm auto release pipeline to be triggered once a tag got created

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 name: Publish to npm Registry
 
 on:
-  push:
+  create:
     tags: 
       - "*"
 


### PR DESCRIPTION
- fix the npm auto release pipeline to be triggered once a tag got created