### PR TITLE
fix: change the prefix for carbon stylesheet

### DIFF
--- a/design-tokens/variables.scss
+++ b/design-tokens/variables.scss
@@ -3,5 +3,5 @@
 
 // This is the prefix for all the carbon components when
 // they are generated
-$bcgov-prefix: 'bcgov';
+$bcgov-prefix: 'bx';
 $primevue-prefix: 'p';


### PR DESCRIPTION
- Changed prefix to match the carbon components one. This will avoid the need of mainting as extra SCSS file.