### PR TITLE
fix: update carbon-components-overrides.scss

### DIFF
--- a/style-sheets/carbon-components-overrides.scss
+++ b/style-sheets/carbon-components-overrides.scss
@@ -15,13 +15,17 @@
 .#{variables.$bcgov-prefix}--list-box__field,
 .#{variables.$bcgov-prefix}--list-box,
 .#{variables.$bcgov-prefix}--number .#{variables.$bcgov-prefix}--number__input-wrapper input[type=number],
-.#{variables.$bcgov-prefix}--pagination,
 .#{variables.$bcgov-prefix}--search-input,
 .#{variables.$bcgov-prefix}--select-input,
 .#{variables.$bcgov-prefix}--text-input,
 .#{variables.$bcgov-prefix}--text-area {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
+}
+
+.#{variables.$bcgov-prefix}--pagination{
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
 }
 
 .#{variables.$bcgov-prefix}--table-expand__button,
@@ -121,8 +125,8 @@
 }
 
 nav.#{variables.$bcgov-prefix}--side-nav {
-  box-shadow: inset -1px 0 0 colors.$gray-20;
-  background-color: var(--bcgov-background-left-panel);
+  border-right: 1px solid colors.$gray-20;
+  background-color: var(--#{variables.$bcgov-prefix}-background-left-panel);
 }
 
 .#{variables.$bcgov-prefix}--side-nav__items {
@@ -135,28 +139,12 @@ nav.#{variables.$bcgov-prefix}--side-nav {
   width: 16rem;
 }
 
-.#{variables.$bcgov-prefix}--grid {
-  padding: 0 !important;
-}
-
 .#{variables.$bcgov-prefix}--tab-content {
   padding: 0 !important;
 }
 
 .#{variables.$bcgov-prefix}--tabs button.#{variables.$bcgov-prefix}--tabs__nav-item--selected {
   font-weight: bold;
-}
-
-.#{variables.$bcgov-prefix}--data-table {
-  padding: 0 !important;
-}
-
-.#{variables.$bcgov-prefix}--data-table tr th{
-  background-color: var(--#{variables.$bcgov-prefix}-layer-01);
-}
-
-.#{variables.$bcgov-prefix}--data-table tr td{
-  background-color: var(--#{variables.$bcgov-prefix}-layer-02);
 }
 
 .#{variables.$bcgov-prefix}--table-header-label {
@@ -168,7 +156,7 @@ nav.#{variables.$bcgov-prefix}--side-nav {
 }
 
 .#{variables.$bcgov-prefix}--header {
-  background-color: var(--bcgov-background-brand) !important;
+  background-color: var(--#{variables.$bcgov-prefix}-background-brand) !important;
 }
 
 ul.#{variables.$bcgov-prefix}--accordion {
@@ -208,21 +196,21 @@ $types: 'error', 'info', 'success', 'warning';
 
 @each $notificationType in $types {
   div.#{variables.$bcgov-prefix}--inline-notification--#{$notificationType}{
-    border-left: 4px solid var(--bcgov-support-#{$notificationType}-inverse);}
+    border-left: 4px solid var(--#{variables.$bcgov-prefix}-support-#{$notificationType}-inverse);}
   div.#{variables.$bcgov-prefix}--inline-notification--low-contrast.#{variables.$bcgov-prefix}--inline-notification--#{$notificationType}{
-    border-left: 4px solid var(--bcgov-support-#{$notificationType});}
+    border-left: 4px solid var(--#{variables.$bcgov-prefix}-support-#{$notificationType});}
   div.#{variables.$bcgov-prefix}--inline-notification--low-contrast.#{variables.$bcgov-prefix}--inline-notification--#{$notificationType}::before{
-    border-color: var(--bcgov-notification-border-#{$notificationType});}
+    border-color: var(--#{variables.$bcgov-prefix}-notification-border-#{$notificationType});}
 }
 
 @each $notificationType in $types {
   div.#{variables.$bcgov-prefix}--toast-notification--#{$notificationType}{
-    border-left: 4px solid var(--bcgov-support-#{$notificationType}-inverse);}
+    border-left: 4px solid var(--#{variables.$bcgov-prefix}-support-#{$notificationType}-inverse);}
   div.#{variables.$bcgov-prefix}--toast-notification--low-contrast.#{variables.$bcgov-prefix}--toast-notification--#{$notificationType}{
-    border-left: 4px solid var(--bcgov-support-#{$notificationType});
-    border-top-color: var(--bcgov-notification-border-#{$notificationType});
-    border-bottom-color: var(--bcgov-notification-border-#{$notificationType});
-    border-right-color: var(--bcgov-notification-border-#{$notificationType})}
+    border-left: 4px solid var(--#{variables.$bcgov-prefix}-support-#{$notificationType});
+    border-top-color: var(--#{variables.$bcgov-prefix}-notification-border-#{$notificationType});
+    border-bottom-color: var(--#{variables.$bcgov-prefix}-notification-border-#{$notificationType});
+    border-right-color: var(--#{variables.$bcgov-prefix}-notification-border-#{$notificationType})}
 }
 
 .#{variables.$bcgov-prefix}--overflow-menu.bcgov--overflow-menu--open{


### PR DESCRIPTION
This PR brings in the latest changes from SPAR's `components-overrides.scss`

- removed some `!important` where the usage is incorrect that made it impossible for custom styling and messed up the layout for `FlexGrid` & `Grid`.

- A former developer also added styling for his component to this file and those have been removed as well.

- Hard coded prefix `--bcgov` have been replaced with `--#{variables.$bcgov-prefix}`