### PR TITLE
fix: remove important and breadcrumb styles

### DIFF
--- a/style-sheets/carbon-components-overrides.scss
+++ b/style-sheets/carbon-components-overrides.scss
@@ -271,32 +271,6 @@ li.#{variables.$bcgov-prefix}--overflow-menu-options__option:last-child {
   color: colors.$gray-100;
 }
 
-.#{variables.$bcgov-prefix}--breadcrumb {
-  display: flex;
-  flex-direction: column;
-  gap: 2.5rem;
-}
-
-@media screen and (max-width: 671px) {
-  .#{variables.$bcgov-prefix}--breadcrumb-indicator {
-    flex-direction: column;
-  }
-  .#{variables.$bcgov-prefix}--breadcrumb-step {
-    border-left: solid 0.125rem;
-    flex: none;
-  }
-}
-
-@media screen and (min-width: 672px) {
-  .#{variables.$bcgov-prefix}--breadcrumb-indicator {
-    flex-direction: row;
-  }
-  .#{variables.$bcgov-prefix}--breadcrumb-step {
-    border-top: solid 0.125rem;
-    flex: 1;
-  }
-}
-
 .#{variables.$bcgov-prefix}--header {
   background-color: colors.$blue-60 !important;
   display: relative;

--- a/style-sheets/carbon-components-overrides.scss
+++ b/style-sheets/carbon-components-overrides.scss
@@ -87,13 +87,13 @@
 }
 
 .#{variables.$bcgov-prefix}--btn {
-  border-radius: 0.25rem !important;
-  width: 15.188rem !important;
+  border-radius: 0.25rem;
+  width: 15.188rem;
   padding: 0.188rem;
 }
 
 #{variables.$bcgov-prefix}-btn::part(button) {
-  border-radius: 0.25rem !important;
+  border-radius: 0.25rem;
 }
 
 .#{variables.$bcgov-prefix}--btn-header {
@@ -295,85 +295,6 @@ li.#{variables.$bcgov-prefix}--overflow-menu-options__option:last-child {
     border-top: solid 0.125rem;
     flex: 1;
   }
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-indicator {
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 3rem;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step {
-  display: flex;
-  justify-content: space-between;
-  overflow: hidden;
-  height: 3.625rem;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-icon {
-  margin: 0.25rem 0.625rem 0 0;
-  flex-shrink: 0;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-text {
-  flex-grow: 1;
-  overflow: hidden;
-}
-.#{variables.$bcgov-prefix}--breadcrumb-step-text p {
-  font-size: 0.875rem;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-text a, .#{variables.$bcgov-prefix}--breadcrumb-step-text span {
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  display: block;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-text p a {
-  text-decoration: none;
-  color: inherit;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-text p a:hover {
-  text-decoration: underline;
-  cursor: pointer;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-text span {
-  font-size: 0.75rem;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-current {
-  border-color: colors.$blue-60;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-queued {
-  border-color: colors.$gray-20;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-error {
-  border-color: colors.$red-60;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-complete {
-  border-color: colors.$blue-60;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-icon-current {
-  color: colors.$blue-60;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-icon-error {
-  color: colors.$red-60;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-icon-complete {
-  color: colors.$blue-60;
-}
-
-.#{variables.$bcgov-prefix}--breadcrumb-step-icon-queued {
-  color: colors.$gray-20;
 }
 
 .#{variables.$bcgov-prefix}--header {


### PR DESCRIPTION
### Description
This PR remove some of the style overrides that interfere with SPAR. 
I suggest that we keep `component-override.scss`'s changes to a minimal, for extra styles devs should add them to their own project's custom style sheet. 
We should also avoid using `!important` when possible as it is impossible to override it with another style. 

### Summary of changes
- Remove `!important` for `--btn` styles, the problem:
    -  Before
        - ![Screenshot 2023-07-21 at 4 32 39 PM](https://github.com/bcgov/nr-fsa-theme/assets/25162561/d20cff76-6769-44b7-ba40-9818c8ae7265)
    - After
        -  ![Screenshot 2023-07-21 at 4 33 04 PM](https://github.com/bcgov/nr-fsa-theme/assets/25162561/0cb7b4b5-238d-4b27-bc39-3fac7fb3be3d)
- Remove breadcrumb styles as it is not applicable to every project
    -  ![Screenshot 2023-07-21 at 4 34 38 PM](https://github.com/bcgov/nr-fsa-theme/assets/25162561/543ab010-3974-4bbe-bc1c-da0a5a3b13b5)

  