### PR TITLE
fix: removing unused icon selectors for primevue components

### DIFF
--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -45,10 +45,10 @@
 }
 
 label {
-    font-size: 12px;
-    line-height: 16px;
+    font-size: .75rem;
+    line-height: 1rem;
     font-weight: 400;
-    letter-spacing: 0.32px;
+    letter-spacing: .02rem;
     color: map.get(lightTheme.$light-theme, 'text-secondary');
     padding: 0 !important;
 }
@@ -58,14 +58,13 @@ label {
 }
 
 .is-invalid {
-    border: 2px solid map.get(lightTheme.$light-theme, 'support-error') !important;
+    border: .125rem solid map.get(lightTheme.$light-theme, 'support-error') !important;
     border-color: map.get(lightTheme.$light-theme, 'support-error') !important;
-    padding-right: 16px !important;
-    // margin-right: 16px !important;
+    padding-right: 1rem !important;
     background-image: url('../assets/svg/warning--filled.svg') !important;
     background-repeat: no-repeat !important;
     background-position: right calc(0.375em + 0.1875rem) center !important;
-    background-size: 16px 16px !important;
+    background-size: 1rem 1rem !important;
 }
 
 .invalid-feedback {
@@ -76,7 +75,7 @@ label {
 /* ------------------------------------ primevue button --------------------------------- */
 .#{variables.$primevue-prefix}-button {
     @extend %body-compact-01;
-    border-radius: 4px;
+    border-radius: .25rem;
     text-align: left;
     border-color: map.get(
         lightButton.$light-button-token-overrides,
@@ -163,32 +162,32 @@ label {
     color: map.get(lightTheme.$light-theme, 'text-disabled');
     opacity: 1;
     background-color: transparent;
-    border: 1px solid map.get(lightTheme.$light-theme, 'text-disabled');
+    border: .0625rem solid map.get(lightTheme.$light-theme, 'text-disabled');
 }
 
 /* ------------------------------------ primevue inputtext ----------------------------------- */
 .#{variables.$primevue-prefix}-inputtext {
     border: none;
     @extend %body-compact-01;
-    border-bottom: 1px solid
+    border-bottom: .0625rem solid
         map.get(lightTheme.$light-theme, 'border-strong-01');
-    border-radius: 4px 4px 0px 0px;
+    border-radius: .25rem .25rem 0 0;
     background: map.get(lightTheme.$light-theme, 'field-01');
 }
 .#{variables.$primevue-prefix}-inputtext:enabled:hover {
     border-color: map.get(lightTheme.$light-theme, 'border-strong-01');
 }
 .#{variables.$primevue-prefix}-inputtext:enabled:focus {
-    border-bottom: 1px solid map.get(lightTheme.$light-theme, 'background');
+    border-bottom: .0625rem solid map.get(lightTheme.$light-theme, 'background');
     box-shadow: 0 0 0 0.1rem map.get(lightTheme.$light-theme, 'focus');
 }
 
 /* -------------------------------------- primevue dropdown ------------------------------------ */
 .#{variables.$primevue-prefix}-dropdown {
     border: none;
-    border-bottom: 1px solid
+    border-bottom: .0625rem solid
         map.get(lightTheme.$light-theme, 'border-strong-01');
-    border-radius: 4px 4px 0px 0px;
+    border-radius: .25rem .25rem 0 0;
     background: map.get(lightTheme.$light-theme, 'field-01');
 }
 .#{variables.$primevue-prefix}-dropdown
@@ -197,8 +196,8 @@ label {
 }
 
 .#{variables.$primevue-prefix}-dropdown .#{variables.$primevue-prefix}-icon {
-    width: 11px;
-    height: 11px;
+    width: .6875rem;
+    height: .6875rem;
 
     .#{variables.$primevue-prefix}-icon .collapse {
         transform: rotate(180deg);
@@ -209,29 +208,29 @@ label {
         .#{variables.$primevue-prefix}-disabled
     ):hover {
     border: none;
-    border-bottom: 1px solid
+    border-bottom: .0625rem solid
         map.get(lightTheme.$light-theme, 'border-strong-01');
 }
 .#{variables.$primevue-prefix}-dropdown:not(
         .#{variables.$primevue-prefix}-disabled
     ).#{variables.$primevue-prefix}-focus {
-    border-bottom: 1px solid map.get(lightTheme.$light-theme, 'background');
+    border-bottom: .0625rem solid map.get(lightTheme.$light-theme, 'background');
     box-shadow: 0 0 0 0.1rem map.get(lightTheme.$light-theme, 'focus');
 }
 
 .#{variables.$primevue-prefix}-dropdown-panel {
     background: map.get(lightTheme.$light-theme, 'layer-01');
-    box-shadow: 0px 2px 6px map.get(lightTheme.$light-theme, 'shadows-menu');
-    border-radius: 0px 0px 4px 4px;
+    box-shadow: 0 .125rem .375rem map.get(lightTheme.$light-theme, 'shadows-menu');
+    border-radius: 0 0 .25rem .25rem;
 }
 .#{variables.$primevue-prefix}-dropdown-panel
     .#{variables.$primevue-prefix}-dropdown-items {
-    padding: 0px;
+    padding: 0;
 }
 .#{variables.$primevue-prefix}-dropdown-panel
     .#{variables.$primevue-prefix}-dropdown-items
     .#{variables.$primevue-prefix}-dropdown-item {
-    border-bottom: 1px solid
+    border-bottom: .0625rem solid
         map.get(lightTheme.$light-theme, 'layer-selected-01');
 }
 .#{variables.$primevue-prefix}-dropdown-panel
@@ -279,8 +278,8 @@ label {
 /* ---------------------------------- checkbox -------------------------------- */
 .#{variables.$primevue-prefix}-checkbox
     .#{variables.$primevue-prefix}-checkbox-box {
-    border: 1px solid map.get(lightTheme.$light-theme, 'icon-primary');
-    border-radius: 2px;
+    border: .0625rem solid map.get(lightTheme.$light-theme, 'icon-primary');
+    border-radius: .125rem;
 }
 .#{variables.$primevue-prefix}-checkbox:not(
         .#{variables.$primevue-prefix}-checkbox-disabled
@@ -292,8 +291,8 @@ label {
         .#{variables.$primevue-prefix}-checkbox-disabled
     )
     .#{variables.$primevue-prefix}-checkbox-box.#{variables.$primevue-prefix}-focus {
-    box-shadow: 0 0 0 2px map.get(lightTheme.$light-theme, 'background'),
-        0 0 0 4px map.get(lightTheme.$light-theme, 'focus'), 0 1px 2px 0 black;
+    box-shadow: 0 0 0 .125rem map.get(lightTheme.$light-theme, 'background'),
+        0 0 0 .25rem map.get(lightTheme.$light-theme, 'focus'), 0 .0625rem .125rem 0 black;
     border-color: map.get(lightTheme.$light-theme, 'icon-primary');
 }
 .#{variables.$primevue-prefix}-checkbox
@@ -308,23 +307,23 @@ label {
 .#{variables.$primevue-prefix}-checkbox
     .#{variables.$primevue-prefix}-checkbox-box.#{variables.$primevue-prefix}-highlight
     .#{variables.$primevue-prefix}-checkbox-icon.pi-check {
-    font-size: 12px;
+    font-size: .75rem;
 }
 
 /* ------------------------------------ primevue radio--------------------------------- */
 .#{variables.$primevue-prefix}-radiobutton {
-    width: 18px;
-    height: 18px;
+    width: 1.125rem;
+    height: 1.125rem;
 }
 .#{variables.$primevue-prefix}-radiobutton-icon {
-    width: 8px !important;
-    height: 8px !important;
+    width: .5rem !important;
+    height: .5rem !important;
 }
 .#{variables.$primevue-prefix}-radiobutton
     .#{variables.$primevue-prefix}-radiobutton-box {
-    border: 1px solid map.get(lightTheme.$light-theme, 'icon-primary');
-    width: 18px;
-    height: 18px;
+    border: .0625rem solid map.get(lightTheme.$light-theme, 'icon-primary');
+    width: 1.125rem;
+    height: 1.125rem;
 }
 .#{variables.$primevue-prefix}-radiobutton
     .#{variables.$primevue-prefix}-radiobutton-box:not(
@@ -336,8 +335,8 @@ label {
     .#{variables.$primevue-prefix}-radiobutton-box:not(
         .#{variables.$primevue-prefix}-disabled
     ).#{variables.$primevue-prefix}-focus {
-    box-shadow: 0 0 0 2px map.get(lightTheme.$light-theme, 'background'),
-        0 0 0 4px map.get(lightTheme.$light-theme, 'focus'), 0 1px 2px 0 black;
+    box-shadow: 0 0 0 .125rem map.get(lightTheme.$light-theme, 'background'),
+        0 0 0 .25rem map.get(lightTheme.$light-theme, 'focus'), 0 .0625rem .125rem 0 black;
     border-color: map.get(lightTheme.$light-theme, 'icon-primary');
 }
 .#{variables.$primevue-prefix}-radiobutton
@@ -361,11 +360,11 @@ label {
 /* ------------------------------------ primevue card--------------------------------- */
 .#{variables.$primevue-prefix}-card {
     box-shadow: none;
-    border: 1px solid map.get(lightTheme.$light-theme, 'border-subtle-00');
-    padding: 32px;
+    border: .0625rem solid map.get(lightTheme.$light-theme, 'border-subtle-00');
+    padding: 2rem;
 }
 .#{variables.$primevue-prefix}-card .#{variables.$primevue-prefix}-card-body {
-    padding: 32px;
+    padding: 2rem;
 }
 
 .#{variables.$primevue-prefix}-card
@@ -375,8 +374,8 @@ label {
 }
 
 .#{variables.$primevue-prefix}-card .#{variables.$primevue-prefix}-card-title {
-    font-size: 16px;
-    line-height: 24px;
+    font-size: 1rem;
+    line-height: 1.5rem;
     font-weight: 400;
     margin-bottom: 0;
 }
@@ -384,8 +383,8 @@ label {
 .#{variables.$primevue-prefix}-card
     .#{variables.$primevue-prefix}-card-subtitle {
     @extend %body-compact-01;
-    padding-left: 0px;
-    padding-right: 0px;
+    padding-left: 0;
+    padding-right: 0;
     color: map.get(lightTheme.$light-theme, 'text-secondary');
 }
 
@@ -399,7 +398,7 @@ label {
     > th {
     @extend %body-compact-01;
     background: map.get(lightTheme.$light-theme, 'layer-accent-hover-01');
-    height: 32px;
+    height: 2rem;
     padding: 0 1rem;
     font-weight: 700;
 
@@ -412,7 +411,7 @@ label {
     > td {
     @extend %body-compact-01;
     text-align: left;
-    box-shadow: 0px 1px 0px 0px
+    box-shadow: 0 .0625rem 0 0
         map.get(lightTheme.$light-theme, 'border-subtle-01') inset;
     padding: 0 1rem;
     border: none;
@@ -421,29 +420,29 @@ label {
 /* --------------------------------------- sidenav ------------------------------------ */
 .#{variables.$primevue-prefix}-sidenav-logo {
     img {
-        margin: 0px 0px 16px 3px;
-        width: 140px;
-        height: 32px;
+        margin: 0 0 1rem .1875rem;
+        width: 8.75rem;
+        height: 2rem;
     }
 }
 
 .#{variables.$primevue-prefix}-sidenav {
     position: fixed;
-    padding: 16px 0px;
-    width: 256px;
-    height: calc(100vh - 50px);
-    left: 0px;
-    top: 48px;
+    padding: 1rem 0;
+    width: 16rem;
+    height: calc(100vh - 3.125rem);
+    left: 0;
+    top: 3rem;
     overflow-x: hidden;
     overflow-y: auto;
-    box-shadow: inset -1px 0px 0px map.get(lightTheme.$light-theme, 'border-subtle-00');
+    box-shadow: inset -0.0625rem 0 0 map.get(lightTheme.$light-theme, 'border-subtle-00');
     .content {
         position: relative;
         min-height: auto;
     }
     .support-section {
         position: absolute;
-        bottom: 0px;
+        bottom: 0;
     }
 }
 
@@ -460,7 +459,7 @@ label {
     @extend %helper-text-01;
     color: map.get(lightTheme.$light-theme, 'text-secondary');
     align-items: center;
-    padding: 15px 16px;
+    padding: .9375rem 1rem;
     i {
         vertical-align: middle;
     }
@@ -471,7 +470,7 @@ label {
 
 .#{variables.$primevue-prefix}-sidenav li.child:hover {
     background: map.get(lightTheme.$light-theme, 'layer-selected-01');
-    box-shadow: inset 3px 0px 0px
+    box-shadow: inset .1875rem 0 0
         map.get(lightTheme.$light-theme, 'border-interactive');
     color: map.get(lightTheme.$light-theme, 'text-primary');
     cursor: pointer;
@@ -484,7 +483,7 @@ label {
 
 .#{variables.$primevue-prefix}-sidenav-selected {
     background: map.get(lightTheme.$light-theme, 'layer-selected-01');
-    box-shadow: inset 3px 0px 0px
+    box-shadow: inset .1875rem 0 0
         map.get(lightTheme.$light-theme, 'border-interactive');
     color: map.get(lightTheme.$light-theme, 'text-primary') !important;
     cursor: pointer;
@@ -494,13 +493,13 @@ label {
 ul#nav li.active a {
     color: map.get(lightTheme.$light-theme, 'text-primary');
     background: map.get(lightTheme.$light-theme, 'layer-selected-01');
-    box-shadow: inset 3px 0px 0px
+    box-shadow: inset .1875rem 0 0
         map.get(lightTheme.$light-theme, 'border-interactive');
 }
 
 /* ---------------------------------- dashboard table ---------------------------------- */
 .#{variables.$primevue-prefix}-table-header {
-    padding: 16px 16px 24px;
+    padding: 1rem 1rem 1.5rem;
     h3 {
         @extend %heading-03;
         margin: 0;
@@ -516,16 +515,16 @@ ul#nav li.active a {
 }
 
 .#{variables.$primevue-prefix}-access-table {
-    margin-top: 79px;
+    margin-top: 4.9375rem;
     background: transparent;
-    border-radius: 4px 4px 0px 0px;
-    border: 2px solid map.get(lightTheme.$light-theme, 'border-subtle-00');
+    border-radius: .25rem .25rem 0 0;
+    border: .125rem solid map.get(lightTheme.$light-theme, 'border-subtle-00');
 }
 
 /* ------------------------------------ dialog -------------------------- */
 .#{variables.$primevue-prefix}-dialog {
     border-radius: 0.5rem;
-    box-shadow: 0px 2px 6px 0px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 .125rem .375rem 0 rgba(0, 0, 0, 0.3);
     border: none;
 }
 
@@ -534,20 +533,19 @@ ul#nav li.active a {
 }
 
 .#{variables.$primevue-prefix}-dialog-content p:last-child {
-    padding-bottom: 48px;
+    padding-bottom: 3rem;
     margin: 0;
 }
 .#{variables.$primevue-prefix}-dialog
     .#{variables.$primevue-prefix}-dialog-content:last-of-type {
-    padding-bottom: 120px;
+    padding-bottom: 7.5rem;
     border-bottom-right-radius: 0.5rem;
     border-bottom-left-radius: 0.5rem;
 }
 
-.#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}-dialog-footer {
+.#{variables.$primevue-prefix}-dialog-footer {
     border-top: none;
-    padding-bottom: 64px !important;
+    padding-bottom: 4rem !important;
 }
 
 .#{variables.$primevue-prefix}-dialog
@@ -593,7 +591,7 @@ ul#nav li.active a {
 .#{variables.$primevue-prefix}-dialog
     .#{variables.$primevue-prefix}-confirm-dialog-reject,
 .#{variables.$primevue-prefix}-confirm-dialog-accept {
-    padding: 12px 83px;
+    padding: .75rem 5.1875rem;
 }
 
 /* ------------------------------------ dialog confirm button reject --------------------------         */
@@ -640,7 +638,7 @@ ul#nav li.active a {
         'button-tertiary'
     ) !important;
 
-    border: solid 1px
+    border: solid .0625rem
         map.get(lightButton.$light-button-token-overrides, 'button-tertiary') !important;
 }
 
@@ -702,9 +700,9 @@ ul#nav li.active a {
         'notification-background-error'
     ) !important;
 
-    border: solid 1px map-get(lightTheme.$light-theme, 'support-error') !important;
+    border: solid .0625rem map-get(lightTheme.$light-theme, 'support-error') !important;
 
-    border-left: solid 5px map-get(lightTheme.$light-theme, 'support-error') !important;
+    border-left: solid  .3125rem map-get(lightTheme.$light-theme, 'support-error') !important;
 }
 
 .#{variables.$primevue-prefix}-toast
@@ -717,12 +715,12 @@ ul#nav li.active a {
 .#{variables.$primevue-prefix}-message
     .#{variables.$primevue-prefix}-message-text {
     @extend %body-compact-01;
-    padding-left: 4px;
+    padding-left: .25rem;
 }
 
 .#{variables.$primevue-prefix}-message
     .#{variables.$primevue-prefix}-message-wrapper {
-    padding: 0 8px 0 0;
+    padding: 0 .5rem 0 0;
 }
 
 .#{variables.$primevue-prefix}-message-wrapper
@@ -736,8 +734,8 @@ ul#nav li.active a {
 }
 
 .#{variables.$primevue-prefix}-icon {
-    height: 12px;
-    width: 12px;
+    height: .75rem;
+    width: .75rem;
 }
 
 .#{variables.$primevue-prefix}-message-wrapper
@@ -746,8 +744,8 @@ ul#nav li.active a {
 }
 
 .#{variables.$primevue-prefix}-message-success {
-    border: solid 1px map.get(lightTheme.$light-theme, 'support-success') !important;
-    border-left: solid 5px map.get(lightTheme.$light-theme, 'support-success') !important;
+    border: solid .0625rem map.get(lightTheme.$light-theme, 'support-success') !important;
+    border-left: solid .3125rem map.get(lightTheme.$light-theme, 'support-success') !important;
 }
 
 /* --------------------------------------- Header --------------------------------------- */
@@ -755,7 +753,7 @@ ul#nav li.active a {
     @extend %heading-compact-01;
     position: fixed;
 
-    height: 48px;
+    height: 3rem;
     width: 100vw;
     background: map.get(lightTheme.$light-theme, 'background-brand');
 
@@ -776,7 +774,7 @@ ul#nav li.active a {
     .navbar {
         margin: 0;
         padding: 0;
-        height: 48px;
+        height: 3rem;
         vertical-align: middle;
     }
 

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -498,14 +498,6 @@ ul#nav li.active a {
         map.get(lightTheme.$light-theme, 'border-interactive');
 }
 
-.#{variables.$primevue-prefix}-sidenav-padding-icon {
-    margin-right: 25px;
-}
-
-.#{variables.$primevue-prefix}-sidenav-color-icon {
-    color: map.get(lightTheme.$light-theme, 'interactive');
-}
-
 /* ---------------------------------- dashboard table ---------------------------------- */
 .#{variables.$primevue-prefix}-table-header {
     padding: 16px 16px 24px;

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -677,20 +677,12 @@ ul#nav li.active a {
 }
 
 .#{variables.$primevue-prefix}-toast
-    .#{variables.$primevue-prefix}-toast-icon-close {
+    .#{variables.$primevue-prefix}-toast-icon-close svg{
     color: map.get(
         lightNotifications.$light-notification-token-overrides,
         'notification-action-tertiary-inverse-text'
     ) !important;
-}
-
-.#{variables.$primevue-prefix}-toast
-    .#{variables.$primevue-prefix}-toast-icon-close
-    svg {
-    color: map.get(
-        lightNotifications.$light-notification-token-overrides,
-        'notification-action-tertiary-inverse-text'
-    ) !important;
+    margin-top: 0 !important;
 }
 
 .#{variables.$primevue-prefix}-toast
@@ -698,8 +690,9 @@ ul#nav li.active a {
     box-shadow: 0 0 0 0.1rem map.get(lightTheme.$light-theme, 'support-error') !important;
 }
 
-.#{variables.$primevue-prefix}-toast-message-content .svg {
-    color: map.get(lightTheme.$light-theme, 'support-error');
+.#{variables.$primevue-prefix}-toast-message-content svg {
+    flex-shrink:0 !important;
+    margin-top: .25rem !important;
 }
 
 .#{variables.$primevue-prefix}-toast

--- a/style-sheets/primevue-components-overrides.scss
+++ b/style-sheets/primevue-components-overrides.scss
@@ -529,30 +529,8 @@ ul#nav li.active a {
     border: none;
 }
 
-.#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}-dialog-header {
-    border-top-right-radius: 0.5rem;
-    border-top-left-radius: 0.5rem;
-
-    .#{variables.$primevue-prefix}-dialog-title {
-        @extend %heading-03;
-    }
-}
-
-.#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}-dialog-footer {
-    border-bottom-right-radius: 0.5rem;
-    border-bottom-left-radius: 0.5rem;
-}
-
 .#{variables.$primevue-prefix}-dialog-content {
     @extend %body-compact-01;
-}
-
-.#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}dialog-header
-    .#{variables.$primevue-prefix}-dialog-header-icon:focus {
-    box-shadow: none;
 }
 
 .#{variables.$primevue-prefix}-dialog-content p:last-child {
@@ -566,8 +544,16 @@ ul#nav li.active a {
     border-bottom-left-radius: 0.5rem;
 }
 
-.#{variables.$primevue-prefix}-dialog-footer {
+.#{variables.$primevue-prefix}-dialog
+    .#{variables.$primevue-prefix}-dialog-footer {
+    border-top: none;
     padding-bottom: 64px !important;
+}
+
+.#{variables.$primevue-prefix}-dialog
+    .#{variables.$primevue-prefix}-dialog-footer {
+    border-bottom-right-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
 }
 
 /* ------------------------------------ dialog confirm header -------------------------- */
@@ -575,19 +561,32 @@ ul#nav li.active a {
 .#{variables.$primevue-prefix}-dialog
     .#{variables.$primevue-prefix}-dialog-header {
     border-bottom: none;
-
     padding-bottom: 0;
+
+    display: inline;
+
+    border-top-right-radius: 0.5rem;
+    border-top-left-radius: 0.5rem;
+
+    .#{variables.$primevue-prefix}-dialog-title {
+        @extend %heading-03;
+    }
 }
 
 .#{variables.$primevue-prefix}-dialog
-    .#{variables.$primevue-prefix}-dialog-footer {
-    border-top: none;
+    .#{variables.$primevue-prefix}-dialog-header-icons {
+    float: right;
+}
+
+.#{variables.$primevue-prefix}-dialog
+    .#{variables.$primevue-prefix}dialog-header
+    .#{variables.$primevue-prefix}-dialog-header-icon:focus {
+    box-shadow: none;
 }
 
 .#{variables.$primevue-prefix}-dialog-header-icon
     .#{variables.$primevue-prefix}-icon {
     height: 0.6rem;
-
     width: 0.6rem;
 }
 


### PR DESCRIPTION
Removed unused css selectors for carbon icons, those are now on the local styles